### PR TITLE
feat: person recognition gate + style guardrails (closes #14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,3 +30,43 @@ Prompt 链接：https://github.com/atomchung/xhs_content_generator/blob/分支�
 - 编辑完文件后必须 commit + push，确保 GitHub 链接可访问
 - 每次 commit message 简要说明改了什么
 - Wemby 的本季数据（得分/篮板/盖帽）为预估值，生图前需替换为实际数据
+
+## 生图铁律（2026-04-19 研究后锁定）
+
+### 风格：一律用 canonical comic break-out prompt
+
+任何 NBA 封面／图组生成，必须读：
+- `explorations/visuals/2026-04-19-nba-cover-style-research.md`
+
+硬性规则：
+- 只替换 `{PLAYER_NAME}` 和 `{ACTION_PHRASE}` 两个变量
+- **禁止**加入 watercolor / aura / speed lines / beams / gold leaf / Chinese ink / Pop Art / geometric / blueprint / minimal / dark / moody
+- **禁止**去掉 `photorealistic foreground transition on the player`
+- 必须含 `--ar 3:4 --stylize 250`
+
+### 真人：必须先跑 Person Recognition Gate
+
+任何 prompt 含真实人物（球员／艺人／政治人物／企业家／KOL）时，生成 prompt 前必须：
+
+1. **读 rubric**：`references/person-confidence-rubric.md`
+2. **对每个人物自评信心度 0-100**，输出 JSON：
+   ```json
+   {"person": "...", "confidence": 65, "tier": "MED", "reason": "...", "anchors_suggestion": "..."}
+   ```
+3. **根据 tier 行为**：
+   - 🟢 HIGH (75+)：直接用名字
+   - 🟡 MED (40-74)：自动加 `anchors_suggestion` 进 prompt + 对话中提示用户
+   - 🔴 LOW (0-39)：**暂停**，要求用户确认是否跑 photo pipeline
+4. **LOW 的 photo pipeline**：
+   - 运动号优先 ESPN：`python scripts/fetch_player_photo.py --player "{name}"`
+   - 其他领域 fallback Wikipedia API
+   - 产物 embed 进 prompt 替代 anchors
+
+### 决策参考（运动号常见）
+
+| 人物类型 | Tier | 做法 |
+|---|---|---|
+| LeBron / Curry / Jokic 级 | 🟢 HIGH | 只写名字 |
+| Rui Hachimura | 🟢 HIGH（实测 OK） | 只写名字 |
+| Cade / Kennard 级轮换 | 🟡 MED | 加外貌锚点 |
+| 大学球员／选秀生（Flagg / Bailey 等）| 🔴 LOW | **必跑 photo pipeline** |

--- a/references/person-confidence-rubric.md
+++ b/references/person-confidence-rubric.md
@@ -1,0 +1,160 @@
+# Person Recognition Confidence Rubric
+
+> Version: 2026-04-19 v1
+> Purpose: 判斷 AI 生圖模型（MJ / Flux / SD）對某真人的訓練集深度，決定生圖前是否需要跑 photo pipeline
+> Scope: 通用 — 適用任何真人主題（運動員 / 藝人 / 政治人物 / 企業家 / KOL）
+
+---
+
+## 評分方式
+
+在任何需要生真人圖的 skill 啟動時，對 prompt 中每個真實人物跑一次信心自評：
+
+### 核心問題
+> 「**AI 生圖模型的訓練集裡，有多少這個人的照片**？」
+>
+> 注意：不是問 Claude 自己認不認得（Claude 知道歷史人物、Claude 讀過的新聞人物），而是問生圖模型（MJ / Flux / SD）訓練時看過多少此人的視覺資料。
+
+### 基礎分數錨點（0-100）
+
+| 分數 | 類型 | 範例 |
+|---|---|---|
+| 100 | 全球 icon | Obama / Taylor Swift / LeBron James / Messi / Elon Musk |
+| 85 | 主流名人，長期曝光 5 年以上 | Nikola Jokic / Jimmy Fallon / Tim Cook / Zendaya |
+| 65 | 領域內知名但破圈有限 | Rui Hachimura / 中堅期歌手 / unicorn 創始人 |
+| 45 | 有曝光但臉譜不穩 | Cade Cunningham / 新生代藝人 / Series B CEO |
+| 25 | 少量公開照片 | 大學球員 / G League / 地方政治人物 |
+| 5 | 幾乎無訓練資料 | 未進聯盟選秀生 / 小眾 KOL / 非公眾人物 |
+
+### 扣分條件（可累加）
+
+| 條件 | 扣分 | 理由 |
+|---|---|---|
+| 2024 年後才進入主流視野 | -10 | 訓練集可能來不及涵蓋 |
+| 同名亞洲人（漢字/拼音歧義）| -15 | AI 容易畫錯人 |
+| 形象高度依賴造型（化妝 / 舞台服 / 制服）| -10 | 脫下造型後臉譜不穩 |
+
+---
+
+## 輸出格式（JSON）
+
+Skill 應要求 Claude 回傳：
+
+```json
+{
+  "person": "person name",
+  "confidence": 65,
+  "tier": "MED",
+  "reason": "Japanese-Zimbabwean Lakers rotation player, 6 seasons in NBA but not All-Star level.",
+  "anchors_suggestion": "Japanese-Zimbabwean heritage, 6'8 lean build, short black hair, angular jawline"
+}
+```
+
+- `confidence` 整數 0-100
+- `tier` 取值：`HIGH` / `MED` / `LOW`
+- `reason` 一句話解釋
+- `anchors_suggestion` 僅當 `tier == "MED"` 時填，否則 `null`
+
+### Tier 對照
+
+```
+confidence >= 75  →  tier = "HIGH"
+40 <= confidence < 75  →  tier = "MED"
+confidence < 40   →  tier = "LOW"
+```
+
+---
+
+## 三檔行為
+
+### 🟢 HIGH（75+）
+直接在 prompt 中用名字，不加額外外貌錨點。
+
+範例 prompt 片段：
+```
+LeBron James mid-air tomahawk dunk, ...
+```
+
+### 🟡 MED（40-74）
+1. 在 prompt 中加入 `anchors_suggestion` 作為外貌錨點（括號內）
+2. 在對話中提示用戶信心度
+
+範例 prompt 片段：
+```
+Rui Hachimura (Japanese-Zimbabwean heritage, 6'8 lean build, short black hair, 
+angular jawline) mid-range turnaround jumper, ...
+```
+
+對話提示模板：
+```
+⚠️ {person_name} 辨識度 {score}（MED）
+已自動加入外貌錨點：{anchors_suggestion}
+若生圖後辨識度仍不理想，可手動跑 photo pipeline 取得更精準描述。
+```
+
+### 🔴 LOW（0-39）
+**不直接輸出 prompt**，先向用戶確認：
+
+```
+🔴 {person_name} 辨識度 {score}（LOW）
+AI 生圖模型對此人辨識度不足，直接用名字會畫錯臉。
+
+選擇：
+(A) 自動跑 photo pipeline（ESPN 首選 → Wikipedia 備援）
+    → python scripts/fetch_player_photo.py --player "{name}"
+(B) 手動提供此人 3-5 張參考照片路徑
+(C) 忽略辨識度，直接用名字生（預期會畫錯臉）
+```
+
+---
+
+## Photo Pipeline 整合
+
+當 `tier == "LOW"` 且用戶選 (A)，跑：
+
+```bash
+python scripts/fetch_player_photo.py --player "{name}" [--espn-id {id}]
+```
+
+優先順序（運動帳號）：
+1. **ESPN** — 官方 headshot，解析度穩定，帶 player_id 時最準
+2. **Wikipedia API** — 無需 ID，通用備援
+3. **（未來）Google Images 首圖** — 最後手段
+
+Pipeline 產物：
+- `references/players/{slug}/espn_headshot.png`（或 `wikipedia_photo.jpg`）
+- `references/players/{slug}/appearance.md`（3-5 句外貌描述，由 Claude 讀圖後寫）
+
+生圖 prompt 生成時 embed `appearance.md` 的描述替代 `anchors_suggestion`。
+
+---
+
+## 決策範例（NBA 主題）
+
+| 人物 | 基礎分 | 扣分 | 最終 | Tier | 做法 |
+|---|---|---|---|---|---|
+| LeBron James | 100 | 0 | **100** | 🟢 | 只寫名字 |
+| Nikola Jokic | 85 | 0 | **85** | 🟢 | 只寫名字 |
+| Rui Hachimura | 65 | 0 | **65** | 🟡 | 加外貌錨點（實測 OK 可降為 HIGH）|
+| Cade Cunningham | 45 | 0 | **45** | 🟡 | 加外貌錨點 |
+| Luke Kennard | 45 | 0 | **45** | 🟡 | 加外貌錨點 |
+| Cooper Flagg | 25 | -10（2024+）| **15** | 🔴 | **必跑 photo pipeline** |
+| Ace Bailey | 25 | -10 | **15** | 🔴 | **必跑 photo pipeline** |
+| Dylan Harper | 25 | -10 | **15** | 🔴 | **必跑 photo pipeline** |
+| VJ Edgecombe | 25 | -10 | **15** | 🔴 | **必跑 photo pipeline** |
+
+---
+
+## 反饋校準日誌
+
+當生圖實測結果和 rubric 預期不符時，在此記錄，用於未來版本調整 rubric 分數錨點。
+
+| 日期 | 人物 | Rubric 預測 | 實測結果 | 應調整 |
+|---|---|---|---|---|
+| 2026-04-19 | Rui Hachimura | MED（65）| 辨識度實際 OK | 可考慮錨點列為 70+ 直接 HIGH |
+
+---
+
+## 版本歷史
+
+- **2026-04-19 v1**：首版。ESPN 為運動帳號首選 photo source。Rui 實測 OK 註記。

--- a/skills/xhs-cover-template/SKILL.md
+++ b/skills/xhs-cover-template/SKILL.md
@@ -5,6 +5,23 @@ description: 为小红书帖子锁定首图封面结构的首图检查器。默�
 
 # XHS Cover Template
 
+## 开工前必读（2026-04-19 生图铁律）
+
+做任何涉及生图的封面决策前，**必须**做两件事：
+
+1. **风格**：读 `explorations/visuals/2026-04-19-nba-cover-style-research.md`
+   - NBA 封面一律用 canonical comic break-out prompt（只替换 `{PLAYER_NAME}` 和 `{ACTION_PHRASE}`）
+   - 禁用词：watercolor / aura / speed lines / beams / gold leaf / Chinese ink / Pop Art / geometric / blueprint / minimal / dark / moody
+   - 必保留 `photorealistic foreground transition on the player`
+
+2. **真人辨识度 Gate**：读 `references/person-confidence-rubric.md`
+   - 对封面中每个真人自评信心度 0-100
+   - 🟢 HIGH (75+)：直接用名字
+   - 🟡 MED (40-74)：加外貌锚点进 prompt + 对话中提示
+   - 🔴 LOW (0-39)：**暂停**，要求用户确认是否跑 photo pipeline
+
+---
+
 这个 skill 先做一件事：在首图阶段快速确认封面有没有站住。
 
 默认要先过一次简版 `cover check`：

--- a/skills/xhs-image-style-duo/SKILL.md
+++ b/skills/xhs-image-style-duo/SKILL.md
@@ -5,6 +5,25 @@ description: 为已确定要生图的页面输出默认 `1` 个推荐风格和 `
 
 # XHS Image Style Duo
 
+## 开工前必读（2026-04-19 生图铁律）
+
+在产出任何生图 prompt 前，**必须**做两件事：
+
+1. **风格**：读 `explorations/visuals/2026-04-19-nba-cover-style-research.md`
+   - NBA 图组一律用 canonical comic break-out prompt（只替换 `{PLAYER_NAME}` 和 `{ACTION_PHRASE}`）
+   - 禁用词：watercolor / aura / speed lines / beams / gold leaf / Chinese ink / Pop Art / geometric / blueprint / minimal / dark / moody
+   - 必保留 `photorealistic foreground transition on the player`
+
+2. **真人辨识度 Gate**：读 `references/person-confidence-rubric.md`
+   - 对 prompt 中每个真人自评信心度 0-100（输出 JSON）
+   - 🟢 HIGH (75+)：直接用名字
+   - 🟡 MED (40-74)：加 `anchors_suggestion` 进 prompt + 对话中提示
+   - 🔴 LOW (0-39)：**暂停**，要求用户确认是否跑 photo pipeline（`python scripts/fetch_player_photo.py --player "{name}"`）
+
+违反这两条铁律前请先 stop 并询问用户。
+
+---
+
 这个 skill 只做一件事：
 
 把一个已经锁住任务的页面，变成 `可直接在网页聊天界面里使用的生图 prompt`。


### PR DESCRIPTION
## Summary
Implements the universal real-person recognition gate proposed in #14, plus wires the canonical style prompt from PR #13 into the same pre-flight check. Both image skills (xhs-image-style-duo, xhs-cover-template) now refuse to generate prompts blindly — they run the gate first.

## What landed

### `references/person-confidence-rubric.md` (new, 200+ lines)
- 0-100 confidence scoring with 6 anchor points (LeBron=100 → selection prospect=5)
- Tier thresholds: HIGH 75+ / MED 40-74 / LOW <40
- Deduction rules (2024+ subject -10, name ambiguity -15, costume-dependent -10)
- JSON output format spec
- Behavior template per tier (prompt style + user dialog template)
- Photo pipeline integration (ESPN first for sports, Wikipedia fallback)
- Concrete decision table for NBA personalities
- Feedback calibration log (Rui Hachimura tested HIGH despite rubric-predicted MED — logged)

### `CLAUDE.md` — 生图铁律 section
- Canonical style prompt rules (swap only {PLAYER_NAME}/{ACTION_PHRASE}; no watercolor/aura/etc.)
- Person Recognition Gate (read rubric, self-score, behave by tier)
- Quick decision table

### `skills/xhs-image-style-duo/SKILL.md` + `skills/xhs-cover-template/SKILL.md`
- Prepended 开工前必读 block referencing both the style research doc and the rubric
- Explicit stop-and-ask behavior when tier == LOW

## Why this matters
Before this PR, image skills would pass raw player names to generators regardless of training-set depth. Known players (LeBron, Curry) looked right; borderline players (Cade Cunningham) were a coin-flip; college/draft prospects (Cooper Flagg) were random faces.

The gate makes the skill self-aware: it asks Claude to estimate how well the image model knows the person, and only commits to a prompt when confidence is safe. Below threshold, the skill halts and asks for the photo pipeline.

## Test plan
- [ ] Next NBA post with a known player (HIGH) — skill should generate directly
- [ ] Next post mentioning Cade Cunningham or similar rotation player (MED) — skill should auto-inject appearance anchors + flag to user
- [ ] Next post with draft prospect (LOW) — skill should halt and offer pipeline choices
- [ ] Track Rui Hachimura generation quality — if consistently HIGH-level output, adjust rubric base score upward in next version

## Related
- Closes #14
- Builds on #13 (merged, canonical style prompt)
- Complements #12 (open — photo pipeline script); once this lands, #12's pipeline has a proper trigger mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)